### PR TITLE
fix: prevent collapsed sidebar title overlap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ All notable changes to Supernova are documented in this file.
 
 ### Fixed
 
+- Fixed session titles overlapping the forward navigation button when the sidebar was closed on Windows and Linux.
 - Fixed opening uncached sessions repeatedly parsing every saved Pi session.
 - Fixed failed session title generation persisting a placeholder instead of falling back to the first user message.
 - Fixed OAuth-backed providers failing to send messages in packaged desktop builds.

--- a/packages/web/src/features/sessions/components/session-layout.tsx
+++ b/packages/web/src/features/sessions/components/session-layout.tsx
@@ -16,7 +16,7 @@ interface SessionLayoutProps {
 
 export default function SessionLayout(props: SessionLayoutProps) {
   const {appEnvironment, attachmentDropOverlayVisible = false, attachmentDropZoneProps, composer, timeline, title, titleActions} = props;
-  const titleOffset = appEnvironment === "mac" ? "left-48" : appEnvironment === "web" ? "left-12" : "left-20";
+  const titleOffset = appEnvironment === "mac" ? "left-48" : appEnvironment === "web" ? "left-12" : "left-29";
 
   return (
     <div {...attachmentDropZoneProps} className="relative flex min-h-0 min-w-0 flex-1 flex-col">


### PR DESCRIPTION
## Problem

When the sidebar is collapsed on Windows, the session title is positioned too far to the left and overlaps the forward navigation button.

The title has enough spacing when the sidebar is expanded, but the collapsed layout needs a larger horizontal offset to keep the header elements separated.

## Testing

Manually verified on Windows with the sidebar both collapsed and expanded.

### Sidebar collapsed

<img width="1266" height="793" alt="left_closed" src="https://github.com/user-attachments/assets/482c1c23-fa98-49b5-8bcf-87c4cb9b30c4" />