### PR TITLE
fix(desktop): sharpen Windows titlebar icon

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ All notable changes to Supernova are documented in this file.
 ### Fixed
 
 - Fixed session titles overlapping the forward navigation button when the sidebar was closed on Windows and Linux.
+- Fixed the Windows title-bar app icon appearing pixelated at small display sizes.
 - Fixed opening uncached sessions repeatedly parsing every saved Pi session.
 - Fixed failed session title generation persisting a placeholder instead of falling back to the first user message.
 - Fixed OAuth-backed providers failing to send messages in packaged desktop builds.

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -138,7 +138,8 @@ function iconsDir(): string {
 }
 
 function iconPath(): string {
-  return join(iconsDir(), "icon.png");
+  const filename = process.platform === "win32" ? "icon.ico" : "icon.png";
+  return join(iconsDir(), filename);
 }
 
 // Keep Chromium profile state, localStorage, cookies, and DevTools state isolated


### PR DESCRIPTION
# Problem

On Windows, the Supernova icon displayed in the native title bar appears blurry and pixelated at its small rendered size.

This makes the title-bar icon look noticeably lower quality than the rest of the application UI.

# Before 

<img width="240" height="69" alt="electron_uEV5E7108j" src="https://github.com/user-attachments/assets/5444504a-2809-40ca-9c0a-a866ed49c539" />

# After

<img width="240" height="69" alt="electron_YTjtLPX4sM" src="https://github.com/user-attachments/assets/00d0c1cf-06ea-436e-a68d-ecac1fb3fd2a" />

# Testing

Manually verified on Windows that the title-bar icon renders cleanly at the native title-bar size.