### PR TITLE
feat(desktop): add windows translucent sidebar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ All notable changes to Supernova are documented in this file.
 
 ### Added
 
+- Added native Windows translucency to the sidebar, matching the existing macOS appearance setting.
+
 ### Changed
 
 - Changed new user messages to be scrolled to the top when sent.

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -118,8 +118,12 @@ function resolveRendererUrl(): string {
 
 function windowChromeOptions(): Pick<
   BrowserWindowConstructorOptions,
-  "backgroundColor" | "titleBarStyle" | "trafficLightPosition" | "vibrancy" | "visualEffectState"
+  "backgroundColor" | "backgroundMaterial" | "titleBarStyle" | "trafficLightPosition" | "vibrancy" | "visualEffectState"
 > {
+  if (process.platform === "win32") {
+    return {backgroundMaterial: "acrylic"};
+  }
+
   if (process.platform !== "darwin") {
     return {};
   }

--- a/packages/web/src/app/styles.css
+++ b/packages/web/src/app/styles.css
@@ -150,7 +150,7 @@
     background: var(--theme-surface-sidebar);
   }
 
-  :root[data-app-environment="mac"][data-translucent-sidebar="true"] .desktop-sidebar-background {
+  :root:is([data-app-environment="mac"], [data-app-environment="windows"])[data-translucent-sidebar="true"] .desktop-sidebar-background {
     background: var(--theme-surface-sidebar-translucent);
     backdrop-filter: blur(8px) saturate(135%);
   }


### PR DESCRIPTION
## Feature

Adds a translucent sidebar effect to the Windows desktop app, bringing an effect that was previously available only on macOS to Windows while keeping the main session area fully opaque.

## Windows translucent sidebar

<img width="1919" height="1032" alt="explorer_KHGty6xOpY" src="https://github.com/user-attachments/assets/0873966d-0883-426e-b2b2-1009ae1294e2" />

## Testing

Manually verified on Windows with the sidebar expanded and the translucent background enabled.